### PR TITLE
Fix regression in commutative matching

### DIFF
--- a/matchpy/expressions/functions.py
+++ b/matchpy/expressions/functions.py
@@ -13,8 +13,6 @@ __all__ = [
 
 def is_constant(expression):
     """Check if the given expression is constant, i.e. it does not contain Wildcards."""
-    if isinstance(expression, Expression):
-        return expression.is_constant
     if isinstance(expression, Operation):
         return all(is_constant(o) for o in op_iter(expression))
     return not isinstance(expression, Wildcard)


### PR DESCRIPTION
Before 2960af0 in  diofant/diofant#526 I have match for
```
x_, y_ = Wild('x'), Wild('y')
p2 = matchpy.Pattern(x_ + y_)
list(matchpy.match(x + 2*y, p2))
```

But after this commit - no match anymore.

Not sure if current "fix" is correct, but I believe there is some regression.  Or something is wrong with my binding to matchpy.
