### PR TITLE
Configure setuptools.setup() with setup.cfg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ python:
   - 3.6
   - 3.7-dev
 install:
-  - pip install -r requirements.txt
-  - pip install coveralls
-  - python setup.py -V
+  - pip install .[tests,develop]
 script:
   - make coverage
 after_success:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,49 @@
+[metadata]
+name = matchpy
+description = A library for pattern matching on symbolic expressions.
+long_description = file: README.rst
+author = Manuel Krebber
+author_email = admin@wheerd.de
+url = https://github.com/HPAC/matchpy
+license = MIT
+classifiers = Development Status :: 3 - Alpha
+              Intended Audience :: Developers
+              License :: OSI Approved :: MIT License
+              Programming Language :: Python
+              Programming Language :: Python :: 3
+              Programming Language :: Python :: 3.6
+              Programming Language :: Python :: 3.7
+              Programming Language :: Python :: Implementation :: CPython
+project_urls = Source = https://github.com/HPAC/matchpy
+               Tracker = https://github.com/HPAC/matchpy/issues
+               Documentation = https://matchpy.readthedocs.io/
+
+[options]
+use_scm_version = True
+packages = find:
+zip_safe = True
+test_suite = tests
+python_requires = >=3.6
+setup_requires = setuptools>=36.7.0
+                 setuptools_scm>=1.7.0
+                 pytest-runner
+tests_require = matchpy[tests]
+install_requires = hopcroftkarp>=1.2,<2.0
+                   multiset>=2.0,<3.0
+
+[options.packages.find]
+exclude = tests
+
+[options.extras_require]
+graphs = graphviz>=0.5,<0.6
+tests = pytest>=3.0,<4.0
+        hypothesis>=3.6,<4.0
+develop = Sphinx>=1.4,<2.0
+          pylint>=1.6,<2.0
+          coverage>=4.2,<5.0
+          pytest-cov>=2.4,<3.0
+          coveralls
+
 [flake8]
 max-line-length = 120
 
@@ -17,4 +63,4 @@ split_penalty_before_if_expr = 30
 split_before_first_argument = True
 
 [aliases]
-test=pytest
+test = pytest

--- a/setup.py
+++ b/setup.py
@@ -1,48 +1,6 @@
 # -*- coding: utf-8 -*-
-import os.path
 
-from setuptools import setup, find_packages
-
-root = os.path.dirname(__file__)
-
-with open(os.path.join(root, 'README.rst'), encoding='utf-8') as f:
-    readme = f.read()
+import setuptools
 
 
-setup(
-    name="matchpy",
-    use_scm_version=True,
-    description="A library for pattern matching on symbolic expressions.",
-    long_description=readme,
-    author="Manuel Krebber",
-    author_email="admin@wheerd.de",
-    url='https://github.com/HPAC/matchpy',
-    license='MIT',
-    zip_safe=True,
-    packages=find_packages(exclude=('tests', )),
-    test_suite='tests',
-    classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-    ],
-    setup_requires=[
-        'setuptools_scm >= 1.7.0',
-        'pytest-runner',
-    ],
-    tests_require=[
-        'pytest',
-        'hypothesis',
-    ],
-    install_requires=[
-        'hopcroftkarp>=1.2,<2.0',
-        'multiset>=2.0,<3.0',
-    ],
-    extras_require={
-        'graphs': ['graphviz>=0.5,<0.6'],
-    },
-)
-
+setuptools.setup()

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -862,7 +862,7 @@ PARAM_MATCHES = {}
 
 for name, obj in TestMatch.__dict__.items():
     if name.startswith('test_') and hasattr(obj, 'parametrize'):
-        names, values = obj.parametrize.args
+        names, values = obj.parametrize.combined.args
         names = [n.strip() for n in names.split(',')]
         if names == ['expression', 'pattern', 'expected_matches']:
             for expression, pattern, expected_matches in values:


### PR DESCRIPTION
This also fixes warnings for recent pytest.

Some side notes:
* line endings are inconsistent across the project (sometimes dos, sometimes unix).  Should we fix this?
* requirements.txt looks to be redundant and is inconsistent c.f. setup.py info.  I suggest removing this file.
* most of your dependencies specify not just lower bound for versions, but upper bound too (e.g. ``pytest>=3.0,<4.0``).  I'm not sure if this does make sense for a development version, unless you know that some dependency was broken in a new version.