### PR TITLE
Add __version__ variable for module

### DIFF
--- a/matchpy/__init__.py
+++ b/matchpy/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Contains all the necessary classes and functions for pattern matching."""
 
+import pkg_resources
+
 # pylint: disable=wildcard-import
 from . import expressions
 from . import functions
@@ -13,3 +15,5 @@ from .utils import *
 from .matching import *
 
 __all__ = expressions.__all__ + functions.__all__ + utils.__all__ + matching.__all__
+
+__version__ = pkg_resources.get_distribution(__name__).version

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ project_urls = Source = https://github.com/HPAC/matchpy
                Documentation = https://matchpy.readthedocs.io/
 
 [options]
-use_scm_version = True
 packages = find:
 zip_safe = True
 test_suite = tests

--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,4 @@
 import setuptools
 
 
-setuptools.setup()
+setuptools.setup(use_scm_version=True)


### PR DESCRIPTION
Also, it seems that `use_scm_version` option should be in setup.py, setuptools_scm doesn't support setup.cfg (yet).  So, this regression in #39 was fixed too.

@henrik227, it seems you were self-assigned to #31.  Let me know if you have different thoughts on how to provide version info.
