### PR TITLE
Fix documentation building on rtfd

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,8 @@
+formats:
+    - htmlzip
+    - pdf
+python:
+    version: 3
+    pip_install: true
+    extra_requirements:
+        - docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
       python: 3.6
       script:
         - make check
+        - make doc
 install:
   - make init
 script:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,5 @@ api-docs:
 	sphinx-apidoc -n -e -T -o docs/api matchpy
 	make docs
 
-docs:
-	cd docs
-	make html
-	cd ..
+doc:
+	python setup.py build_sphinx -W

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 init:
-	pip install .[tests,develop]
+	pip install .[develop]
 
 test:
 	py.test tests/ --doctest-modules matchpy/ README.rst docs/example.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,7 +161,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,10 +18,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import datetime
-import os
-import sys
-from setuptools_scm import get_version
-sys.path.insert(0, os.path.abspath(os.path.join('..')))
+import matchpy
 
 # -- General configuration ------------------------------------------------
 
@@ -65,7 +62,7 @@ author = 'Manuel Krebber'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 # The full version, including alpha/beta/rc tags.
-release = get_version(root='..')
+release = matchpy.__version__
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2]) # The short X.Y version.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 .. include:: ../README.rst
 
 Table of Contents
-==============
+=================
 
 .. toctree::
    :maxdepth: 2

--- a/matchpy/expressions/constraints.py
+++ b/matchpy/expressions/constraints.py
@@ -163,7 +163,7 @@ class CustomConstraint(Constraint):  # pylint: disable=too-few-public-methods
 
         Raises:
             ValueError:
-                If the callback has positional-only or variable parameters (*args and **kwargs).
+                If the callback has positional-only or variable parameters (\*args and \*\*kwargs).
         """
         self.constraint = constraint
         signature = inspect.signature(constraint)

--- a/matchpy/utils.py
+++ b/matchpy/utils.py
@@ -170,8 +170,8 @@ def _commutative_single_variable_partiton_iter(values: 'Multiset[T]',
             yield {name: new_values} if name is not None else {}
 
 
-def commutative_sequence_variable_partition_iter(values: 'Multiset[T]', variables: List[VariableWithCount]
-                                                ) -> Iterator[Dict[str, 'Multiset[T]']]:
+def commutative_sequence_variable_partition_iter(values: Multiset, variables: List[VariableWithCount]
+                                                ) -> Iterator[Dict[str, Multiset]]:
     """Yield all possible variable substitutions for given values and variables.
 
     .. note::
@@ -437,7 +437,7 @@ def solve_linear_diop(total: int, *coeffs: int) -> Iterator[Tuple[int, ...]]:
 
     1. Compute :math:`d := gcd(c_2, \dots , c_n)`
     2. Solve :math:`c_1 x + d y = total`
-    3. Recursively solve :math:`c_2 x_2 + \dots + c_n x_n = y` for each solution for `y`
+    3. Recursively solve :math:`c_2 x_2 + \dots + c_n x_n = y` for each solution for :math:`y`
     4. Combine these solutions to form a solution for the whole equation
 
     Args:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,0 @@
-conda:
-    file: environment.yml

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,10 @@ exclude = tests
 graphs = graphviz>=0.5,<0.6
 tests = pytest>=3.0,<4.0
         hypothesis>=3.6,<4.0
-develop = Sphinx>=1.4,<2.0
+docs = sphinx_rtd_theme
+       Sphinx>=1.4,<2.0
+develop = %(docs)s
+          %(tests)s
           pylint>=1.6,<2.0
           coverage>=4.2,<5.0
           pytest-cov>=2.4,<3.0


### PR DESCRIPTION
Latest docs build [was broken](https://readthedocs.org/projects/matchpy/builds/8186213/) and you can see that  API docs are missing on rtfd page, e.g. [this](https://matchpy.readthedocs.io/en/latest/api/matchpy.expressions.constraints.html).  It seems, conda build doesn't install package itself, hence these import failures.

I don't sure how to fix this with conda (don't use it locally), so I switched RTFD config to use `pip install .[docs]`.  (Additional setuptools extras was added to track documentation building requirements.)  I believe, this should fix the problem - similar solution does work on the [diofant](https://github.com/diofant/diofant), which also uses `setuptools_scm` to manage versions.

Also code quality tests on Travis CI now include building html docs.

If you think it's an acceptable solution, then after merging - please check docs building on the readthedocs this time.
