### PR TITLE
[Feature] Adding graphviz visualization of expressions

### DIFF
--- a/matchpy/expressions/expressions.py
+++ b/matchpy/expressions/expressions.py
@@ -57,6 +57,7 @@ from typing import Callable, Iterator, List, NamedTuple, Optional, Set, Tuple, T
 from multiset import Multiset
 
 from ..utils import cached_property
+from .visualization import visualize_expression
 
 __all__ = [
     'Expression', 'Arity', 'Atom', 'Symbol', 'Wildcard', 'Operation', 'SymbolWildcard', 'Pattern', 'make_dot_variable',
@@ -422,6 +423,25 @@ class Operation(Expression, metaclass=_OperationMeta):
             return '{!s}({!s}, variable_name={})'.format(type(self).__name__, operand_str, self.variable_name)
         return '{!s}({!s})'.format(type(self).__name__, operand_str)
 
+    def _repr_svg_(self):
+        try:
+            dot = self._repr_gviz_()
+            return dot.pipe(format='svg').decode(dot._encoding)
+        except ImportError as e:
+            return None
+
+    def _repr_gviz_(self):
+        return visualize_expression(self)
+
+    def _repr_gviz_node_(self):
+        description = 'Operation: {!s}\n'.format(self.__class__.__name__)
+        if self.variable_name:
+            description += ', variable_name={!s}'.format(self.variable_name)
+        return (
+            description,
+            dict(shape='oval', color='#455C7B', fillcolor='#9db0c8', style='filled')
+        )
+
     @staticmethod
     def new(
             name: str,
@@ -662,6 +682,25 @@ class Symbol(Atom):
         if self.variable_name:
             return '{!s}({!r}, variable_name={})'.format(type(self).__name__, self.name, self.variable_name)
         return '{!s}({!r})'.format(type(self).__name__, self.name)
+
+    def _repr_svg_(self):
+        try:
+            dot = self._repr_gviz_()
+            return dot.pipe(format='svg').decode(dot._encoding)
+        except ImportError as e:
+            return None
+
+    def _repr_gviz_(self):
+        return visualize_expression(self)
+
+    def _repr_gviz_node_(self):
+        description = 'Symbol: {!s}\n{!s}'.format(self.__class__.__name__, self.name)
+        if self.variable_name:
+            description += ', variable_name={!s}'.format(self.variable_name)
+        return (
+            description,
+            dict(shape='box', color='#AC6C82', fillcolor='#cfaab7', style='filled')
+        )
 
     def collect_symbols(self, symbols):
         symbols.add(self.name)

--- a/matchpy/expressions/visualization.py
+++ b/matchpy/expressions/visualization.py
@@ -14,6 +14,7 @@ def visualize_expression(expr, comment='Matchpy Expression', with_attrs=True):
 
     dot = graphviz.Digraph(comment=comment)
     counter = itertools.count()
+    default_node_attr = dict(color='black', fillcolor='white', fontcolor='black')
 
     def _label_node(dot, expr):
         unique_id = str(next(counter))
@@ -24,7 +25,7 @@ def visualize_expression(expr, comment='Matchpy Expression', with_attrs=True):
             raise ValueError(f'matchpy expression does not have _repr_gviz_node_: "{repr(self)}"')
 
         if with_attrs:
-            dot.attr('node', **node_attr)
+            dot.attr('node', **{**default_node_attr, **node_attr})
         dot.node(unique_id, node_description)
         return unique_id
 

--- a/matchpy/expressions/visualization.py
+++ b/matchpy/expressions/visualization.py
@@ -1,0 +1,41 @@
+import itertools
+
+try:
+    import graphviz
+except ImportError as e:
+    graphviz = None
+
+
+def visualize_expression(expr, comment='Matchpy Expression', with_attrs=True):
+    if graphviz is None:
+        raise ImportError('The graphviz package is required to draw expressions')
+
+    from .expressions import Operation
+
+    dot = graphviz.Digraph(comment=comment)
+    counter = itertools.count()
+
+    def _label_node(dot, expr):
+        unique_id = str(next(counter))
+
+        if hasattr(expr, '_repr_gviz_node_'):
+            node_description, node_attr = expr._repr_gviz_node_()
+        else:
+            raise ValueError(f'matchpy expression does not have _repr_gviz_node_: "{repr(self)}"')
+
+        if with_attrs:
+            dot.attr('node', **node_attr)
+        dot.node(unique_id, node_description)
+        return unique_id
+
+    def _visualize_node(dot, expr):
+        expr_id = _label_node(dot, expr)
+
+        if isinstance(expr, Operation):
+            for sub_expr in expr:
+                sub_expr_id = _visualize_node(dot, sub_expr)
+                dot.edge(expr_id, sub_expr_id)
+        return expr_id
+
+    _visualize_node(dot, expr)
+    return dot


### PR DESCRIPTION
PR based on issue #47 

 - _repr_svg_ method is used to render automatically to jupyter notebooks
 - if `graphviz` is not available jupyter notebook/lab will default to `__repr__`
 - by changing class method `_repr_gviz_node` you can set the description and graphviz attributes

Would love feedback:
  - `vizualization.py` or put function `virualize_expression` directly within `expression.py`
  - what additional properties to show for each node? (is it associative? does it have a variable_name? etc.)
  - what colors to use for nodes by default
 
# Example

```python
import matchpy

class Int(matchpy.Symbol):
    pass

class SpecialInt(matchpy.Symbol):
    def _repr_gviz_node_(self):
        return 'foobar', {'color': 'red', 'fontsize': "100.0"}

class List(matchpy.Operation):
    name = "List"
    arity = matchpy.Arity(0, False)
    
List(Int('a'), SpecialInt('b'))
```
![graph0](https://user-images.githubusercontent.com/1740337/49527768-9854d980-f880-11e8-8663-8e39668ce9e8.png)
