### PR TITLE
Require py3.6 on rtfd builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,10 @@
 formats:
     - htmlzip
     - pdf
+build:
+    image: latest
 python:
-    version: 3
+    version: 3.6
     pip_install: true
     extra_requirements:
         - docs


### PR DESCRIPTION
it seems, #46 doesn't work as default documentation build on rtfd is on CPython 3.5 runtime.  This pr select latest build image and 3.6 version (which is available only for it).

@wheerd, I hope this will finally fix docs build, sorry for the mess.