### PR TITLE
Compatibility with pytest 4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ exclude = tests
 [options.extras_require]
 graphs = graphviz>=0.5,<0.6
 tests = pytest>=4.0,<5.0
-        hypothesis>=3.6,<4.0
+        hypothesis>=3.6,<5.0
 docs = sphinx_rtd_theme
        Sphinx>=1.4,<2.0
 develop = %(docs)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ exclude = tests
 
 [options.extras_require]
 graphs = graphviz>=0.5,<0.6
-tests = pytest>=3.0,<4.0
+tests = pytest>=4.0,<5.0
         hypothesis>=3.6,<4.0
 docs = sphinx_rtd_theme
        Sphinx>=1.4,<2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,8 @@ from matchpy.matching.syntactic import DiscriminationNet
 from matchpy.expressions.functions import preorder_iter
 from matchpy.matching.code_generation import CodeGenerator
 
-def pytest_namespace():
-    return { 'matcher': None }
+def pytest_configure():
+    pytest.matcher = None
 
 def pytest_generate_tests(metafunc):
     if 'match' in metafunc.fixturenames:


### PR DESCRIPTION
`pytest_configure` hook was removed in pytest 4.1.0[1], and the recommended way is
to use `pytest_configure`[2].

[1] https://github.com/pytest-dev/pytest/blob/4.1.0/CHANGELOG.rst#pytest-410-2019-01-05
[2] https://docs.pytest.org/en/latest/deprecations.html#pytest-namespace