### PR TITLE
Custom sorting key for substitute( )

### DIFF
--- a/matchpy/functions.py
+++ b/matchpy/functions.py
@@ -71,6 +71,9 @@ def substitute(expression: Union[Expression, Pattern], substitution: Substitutio
     return _substitute(expression, substitution)[0]
 
 
+_custom_sorting_key = [None]
+
+
 def _substitute(expression: Expression, substitution: Substitution) -> Tuple[Replacement, bool]:
     if getattr(expression, 'variable_name', False) and expression.variable_name in substitution:
         return substitution[expression.variable_name], True
@@ -84,7 +87,10 @@ def _substitute(expression: Expression, substitution: Substitution) -> Tuple[Rep
             if isinstance(result, (list, tuple)):
                 new_operands.extend(result)
             elif isinstance(result, Multiset):
-                new_operands.extend(sorted(result))
+                if _custom_sorting_key[0] is not None:
+                    new_operands.extend(sorted(result, key=_custom_sorting_key[0]))
+                else:
+                    new_operands.extend(sorted(result))
             else:
                 new_operands.append(result)
         if any_replaced:

--- a/matchpy/functions.py
+++ b/matchpy/functions.py
@@ -11,7 +11,7 @@
 
 import itertools
 import math
-from typing import Callable, List, NamedTuple, Sequence, Tuple, Union, Iterable
+from typing import Callable, List, NamedTuple, Sequence, Tuple, Union, Iterable, Optional, Any
 
 from multiset import Multiset
 
@@ -27,7 +27,8 @@ __all__ = ['substitute', 'replace', 'replace_all', 'replace_many', 'is_match', '
 Replacement = Union[Expression, List[Expression]]
 
 
-def substitute(expression: Union[Expression, Pattern], substitution: Substitution) -> Replacement:
+def substitute(expression: Union[Expression, Pattern], substitution: Substitution,
+               sort_key: Optional[Callable[[Expression], Any]] = None) -> Replacement:
     """Replaces variables in the given *expression* using the given *substitution*.
 
     >>> print(substitute(f(x_), {'x': a}))
@@ -68,13 +69,11 @@ def substitute(expression: Union[Expression, Pattern], substitution: Substitutio
     """
     if isinstance(expression, Pattern):
         expression = expression.expression
-    return _substitute(expression, substitution)[0]
+    return _substitute(expression, substitution, sort_key)[0]
 
 
-_custom_sorting_key = [None]
-
-
-def _substitute(expression: Expression, substitution: Substitution) -> Tuple[Replacement, bool]:
+def _substitute(expression: Expression, substitution: Substitution,
+                sort_key: Optional[Callable[[Expression], Any]] = None) -> Tuple[Replacement, bool]:
     if getattr(expression, 'variable_name', False) and expression.variable_name in substitution:
         return substitution[expression.variable_name], True
     elif isinstance(expression, Operation):
@@ -87,8 +86,8 @@ def _substitute(expression: Expression, substitution: Substitution) -> Tuple[Rep
             if isinstance(result, (list, tuple)):
                 new_operands.extend(result)
             elif isinstance(result, Multiset):
-                if _custom_sorting_key[0] is not None:
-                    new_operands.extend(sorted(result, key=_custom_sorting_key[0]))
+                if sort_key is not None:
+                    new_operands.extend(sorted(result, key=sort_key))
                 else:
                     new_operands.extend(sorted(result))
             else:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,9 +2,11 @@
 from hypothesis import assume, given
 import hypothesis.strategies as st
 import pytest
+from multiset import Multiset
 
 from matchpy.expressions.expressions import Arity, Operation, Symbol, Wildcard, Pattern
-from matchpy.functions import ReplacementRule, replace, replace_all, substitute, replace_many, is_match
+from matchpy.functions import ReplacementRule, replace, replace_all, substitute, replace_many, is_match, \
+    _custom_sorting_key
 from matchpy.matching.one_to_one import match_anywhere
 from matchpy.matching.one_to_one import match as match_one_to_one
 from matchpy.matching.many_to_one import ManyToOneReplacer
@@ -52,6 +54,24 @@ class TestSubstitute:
             assert result is not expression, "When substituting, the original expression may not be modified"
         else:
             assert result is expression, "When nothing is substituted, the original expression has to be returned"
+
+    def test_substitute_custom_sorting_key(self):
+        # Check custom sorting key for elements in Multiset when the argument
+        # is passed to `substitute`.
+
+        # Reverse alphabetical sorting:
+        _custom_sorting_key[0] = lambda x: -ord(str(x))
+        expression = f(x_, y_)
+        substitution = {'x': a, 'y': Multiset([b, c])}
+        result = substitute(expression, substitution)
+        assert result == f(a, c, b)
+        assert result != f(a, b, c)
+
+        # Remove custom sorting key, sorting is again alphabetical:
+        _custom_sorting_key[0] = None
+        result = substitute(expression, substitution)
+        assert result != f(a, c, b)
+        assert result == f(a, b, c)
 
 
 def many_replace_wrapper(expression, position, replacement):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -5,8 +5,7 @@ import pytest
 from multiset import Multiset
 
 from matchpy.expressions.expressions import Arity, Operation, Symbol, Wildcard, Pattern
-from matchpy.functions import ReplacementRule, replace, replace_all, substitute, replace_many, is_match, \
-    _custom_sorting_key
+from matchpy.functions import ReplacementRule, replace, replace_all, substitute, replace_many, is_match
 from matchpy.matching.one_to_one import match_anywhere
 from matchpy.matching.one_to_one import match as match_one_to_one
 from matchpy.matching.many_to_one import ManyToOneReplacer
@@ -60,15 +59,14 @@ class TestSubstitute:
         # is passed to `substitute`.
 
         # Reverse alphabetical sorting:
-        _custom_sorting_key[0] = lambda x: -ord(str(x))
+        sort_key = lambda x: -ord(str(x))
         expression = f(x_, y_)
         substitution = {'x': a, 'y': Multiset([b, c])}
-        result = substitute(expression, substitution)
+        result = substitute(expression, substitution, sort_key)
         assert result == f(a, c, b)
         assert result != f(a, b, c)
 
         # Remove custom sorting key, sorting is again alphabetical:
-        _custom_sorting_key[0] = None
         result = substitute(expression, substitution)
         assert result != f(a, c, b)
         assert result == f(a, b, c)


### PR DESCRIPTION
Substitute now accepts custom sorting key to specify custom sorting for elements in Multiset.

This should solve the compatibility problem with SymPy which does not allow comparison operators (`>`, `>=`, `<`, `<=`) to be evaluated to booleans if the truth of the expression cannot be easily determined.